### PR TITLE
Fix comparison text error

### DIFF
--- a/specimens/public-sans-black.html
+++ b/specimens/public-sans-black.html
@@ -111,7 +111,7 @@
 					<div class="georgiabody">body</div>
 				</div>
 				<div class="fontbody" style="z-index:1">
-					body<span>Public Sans Black</span>
+					body<span>Public Sans</span>
 				</div>
 				<div class="arialbody" style="z-index:1">
 					body<span>Arial</span>

--- a/specimens/public-sans-bold.html
+++ b/specimens/public-sans-bold.html
@@ -63,7 +63,7 @@
 							<div class="georgiabody">body</div>
 						</div>
 						<div class="fontbody" style="z-index:1">
-							body<span>Public Sans Black</span>
+							body<span>Public Sans</span>
 						</div>
 						<div class="arialbody" style="z-index:1">
 							body<span>Arial</span>

--- a/specimens/public-sans-extrabold.html
+++ b/specimens/public-sans-extrabold.html
@@ -63,7 +63,7 @@
 							<div class="georgiabody">body</div>
 						</div>
 						<div class="fontbody" style="z-index:1">
-							body<span>Public Sans Black</span>
+							body<span>Public Sans</span>
 						</div>
 						<div class="arialbody" style="z-index:1">
 							body<span>Arial</span>

--- a/specimens/public-sans-extralight.html
+++ b/specimens/public-sans-extralight.html
@@ -63,7 +63,7 @@
 							<div class="georgiabody">body</div>
 						</div>
 						<div class="fontbody" style="z-index:1">
-							body<span>Public Sans Black</span>
+							body<span>Public Sans</span>
 						</div>
 						<div class="arialbody" style="z-index:1">
 							body<span>Arial</span>

--- a/specimens/public-sans-light.html
+++ b/specimens/public-sans-light.html
@@ -63,7 +63,7 @@
 							<div class="georgiabody">body</div>
 						</div>
 						<div class="fontbody" style="z-index:1">
-							body<span>Public Sans Black</span>
+							body<span>Public Sans</span>
 						</div>
 						<div class="arialbody" style="z-index:1">
 							body<span>Arial</span>

--- a/specimens/public-sans-medium.html
+++ b/specimens/public-sans-medium.html
@@ -63,7 +63,7 @@
 							<div class="georgiabody">body</div>
 						</div>
 						<div class="fontbody" style="z-index:1">
-							body<span>Public Sans Black</span>
+							body<span>Public Sans</span>
 						</div>
 						<div class="arialbody" style="z-index:1">
 							body<span>Arial</span>

--- a/specimens/public-sans-regular.html
+++ b/specimens/public-sans-regular.html
@@ -63,7 +63,7 @@
 							<div class="georgiabody">body</div>
 						</div>
 						<div class="fontbody" style="z-index:1">
-							body<span>Public Sans Black</span>
+							body<span>Public Sans</span>
 						</div>
 						<div class="arialbody" style="z-index:1">
 							body<span>Arial</span>

--- a/specimens/public-sans-semibold.html
+++ b/specimens/public-sans-semibold.html
@@ -63,7 +63,7 @@
 							<div class="georgiabody">body</div>
 						</div>
 						<div class="fontbody" style="z-index:1">
-							body<span>Public Sans Black</span>
+							body<span>Public Sans</span>
 						</div>
 						<div class="arialbody" style="z-index:1">
 							body<span>Arial</span>

--- a/specimens/public-sans-thin.html
+++ b/specimens/public-sans-thin.html
@@ -63,7 +63,7 @@
 							<div class="georgiabody">body</div>
 						</div>
 						<div class="fontbody" style="z-index:1">
-							body<span>Public Sans Black</span>
+							body<span>Public Sans</span>
 						</div>
 						<div class="arialbody" style="z-index:1">
 							body<span>Arial</span>


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/public-sans/dw-update-site-black/)

- now all the comparisons say `Public Sans` and not `Public Sans Black`

Fixes https://github.com/uswds/public-sans/issues/50