### PR TITLE
Fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ Public Sans is a good option for sites that currently use Open Sans, Tahoma, Lib
 ![squared](https://raw.githubusercontent.com/uswds/public-sans/master/examples/public-sans-featured-images/public-numerals.png)
 
 ## License
-- Public Sans is licensed under the SIL Open Font License v1.1 (http://scripts.sil.org/OFL)
+- Public Sans is licensed under the SIL Open Font License v1.1 (https://opensource.org/licenses/OFL-1.1)
 - To view the copyright and specific terms and conditions please refer to ofl.txt


### PR DESCRIPTION
The current link to SIL Open Font License points to a broken link in an S3 bucket.  I'm not sure if this is the correct place to point instead, but it is a correct version of the license.