### PR TITLE
USWDS - Banner: remove alt from decorative images in banner.

### DIFF
--- a/site/_includes/gov-banner.html
+++ b/site/_includes/gov-banner.html
@@ -19,7 +19,7 @@
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ "/assets/uswds/img/icon-dot-gov.svg" | relative_url }}" role="img" alt="Government building">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ "/assets/uswds/img/icon-dot-gov.svg" | relative_url }}" role="img" alt="">
           <div class="usa-media-block__body">
             <p>
               <strong>Official websites use .gov</strong>
@@ -29,7 +29,7 @@
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ "/assets/uswds/img/icon-https.svg" | relative_url }}" role="img" alt="Lock">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ "/assets/uswds/img/icon-https.svg" | relative_url }}" role="img" alt="">
           <div class="usa-media-block__body">
             <p>
               <strong>Secure .gov websites use HTTPS</strong>


### PR DESCRIPTION
Part of uswds/uswds#3689

Removes `alt` from decorative banner images.