### PR TITLE
WIP: Include Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ site/assets/css
 report.json
 .jekyll-cache
 .venv
+instance_ufo
+master_ufo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,34 +14,7 @@ By submitting a pull request, you agree to comply with the terms and conditions 
 
 ## Building the Font
 
-This package has been updated to use Python [3](https://www.python.org/downloads/)
-
-> if your local version of Python is different from what is noted in `.python-version` you will need to use a version manager like [pyenv](https://github.com/pyenv/pyenv)
-
-```sh
-python3.8 -m venv .venv
-```
-
-### Activate the virtual env
-```sh
-source .venv/bin/activate
-```
-
-### Install requirements
-```sh
-pip install -r ./requirements.txt --no-cache
-```
-
-### Install node requirements
-```sh
-npm install
-```
-
-### Install OS requirements
-```sh
-brew tap bramstein/webfonttools
-brew install woff2 sfnt2woff-zopfli ttfautohint
-```
+This package has been updated to use Python [3](https://www.python.org/downloads/) and [Docker](docker getting started)
 
 ### Run build
 ```sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# pull official base image
+FROM python:3.8.11-slim
+
+# set work directory
+WORKDIR /usr/src/uswds
+
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+RUN
+brew tap bramstein/webfonttools
+brew install woff2 sfnt2woff-zopfli ttfautohint
+
+# run
+CMD [ "./sources/build.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
 # pull official base image
-FROM python:3.8.11-slim
+FROM linuxbrew/brew:latest
 
 # set work directory
 WORKDIR /usr/src/uswds
 
-# set environment variables
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+# install environment packages
+RUN apt-get update && apt-get install python3.8 pip rsync -y
 
+# bring in our python requirements
 COPY requirements.txt .
+
+# install python dependencies
 RUN pip install -r requirements.txt
-RUN
-brew tap bramstein/webfonttools
-brew install woff2 sfnt2woff-zopfli ttfautohint
+
+# install webfont tools
+RUN brew tap bramstein/webfonttools \
+    && brew install woff2 sfnt2woff-zopfli ttfautohint
 
 # run
 CMD [ "./sources/build.sh" ]

--- a/build-font.sh
+++ b/build-font.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker build -t public_sans_temp .
+docker run -v $(pwd):/usr/src/uswds public_sans_temp

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/uswds/public-sans#readme",
   "scripts": {
-    "build": "./sources/build.sh",
+    "build": "sh build-font.sh",
     "copy-webfonts": "npx gulp copy-webfonts",
     "federalist": "npm run uswds-copy-assets && npm run copy-webfonts && npm run uswds-build-sass",
     "jekyll-install": "gem install bundler && bundle install",


### PR DESCRIPTION
This works to include a docker container that allows maintainers to execute our `build.sh` script inside a controlled env that is not dependent on the current user operating system.

To test:
`npm run build`