### PR TITLE
Public Sans: Use new Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,79 @@
+name: Bug Report 🐞
+description: Report a bug and help Public Sans improve.
+title: "Public Sans - Bug: [YOUR TITLE]"
+labels: ['Type: Bug','Status: Triage','Needs: Confirmation']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the bug
+      description: Add a clear and concise description of the bug. Let us know if it impacts major or minor functionality and if you have workaround.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce the bug
+      description: Describe how to reproduce this issue.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error...
+    validations:
+      required: true
+  - type: textarea
+    id: expectation
+    attributes:
+      label: Expected Behavior
+      description: Add a clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: code
+    attributes:
+      label: Related code
+      description: If available, include relevant code snippets or a link to a demo of the bug.
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Add screenshots to help provide context, if applicable.
+    validations:
+      required: false
+  - type: textarea
+    id: system
+    attributes:
+      label: System setup
+      description: Provide your system details. Be sure to include your USWDS version, device, operating system, and browser (with version).
+      placeholder: |
+        - Public Sans version:
+        - Device:
+        - Operating system:
+        - Browser and version:
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: Please confirm the following
+      options:
+        - label:
+            I agree to follow this project's [Code of
+              Conduct](https://designsystem.digital.gov/about/community/#community-conduct).
+          required: true
+        - label:
+            I checked the [current
+              issues](https://github.com/uswds/public-sans/issues) for
+              duplicate bug reports.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,51 @@
+name: Feature Request 💡
+description: Suggest a new idea for Public Sans.
+title: 'Public Sans - Feature: [YOUR TITLE]'
+labels: ['Type: Feature Request','Status: Triage']
+body:
+  - type: markdown
+    attributes:
+      value: '## Feature Request 💡'
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: "Provide a clear and concise description of what the problem is. Ex. I'm always frustrated when [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: "Describe the solution you'd like"
+      description: "Provide a clear and concise description of what you want to happen."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Describe alternatives you've considered"
+      description: "Provide a clear and concise description of any alternative solutions or features you've considered."
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: "Add any other context or screenshots about the feature request."
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: Please confirm the following
+      options:
+        - label:
+            I agree to follow this project's [Code of
+            Conduct](https://designsystem.digital.gov/about/community/#community-conduct).
+          required: true
+        - label:
+            I checked the [current
+            issues](https://github.com/uswds/public-sans/issues) for
+            duplicate feature requests.
+          required: true


### PR DESCRIPTION
## Description
Related to https://github.com/uswds/uswds-team/issues/175

Demo links (Currently in a test repo):
- [Demo - Choose issue type](https://github.com/amyleadem/issue-template/issues/new/choose)
- [Demo - Bug Report](https://github.com/amyleadem/issue-template/issues/new?assignees=&labels=Type%3A+Bug%2CStatus%3A+Triage%2CNeeds%3A+Confirmation&template=public-sans-bug.yaml&title=Public+Sans+-+Bug%3A+%5BYOUR+TITLE%5D)
- [Demo - Feature Request](https://github.com/amyleadem/issue-template/issues/new?assignees=&labels=Type%3A+Feature+Request%2CStatus%3A+Triage&template=public-sans-feature-request.yaml&title=Public+Sans+-+Feature%3A+%5BYOUR+TITLE%5D)

### Purpose
Improve contributor experience by using new Github issue yaml templates. These templates allow us to:
1. Create defined form fields for each entry
2. Add `required` setting for mandatory information
3. Add default labels and assignees (if desired)
    
### Testing
We will not be able to preview this template in USWDS until it is merged, but you can view the templates in action in this test repo: https://github.com/amyleadem/issue-template
