### PR TITLE
Add GSA security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+As a U.S. Government agency, the General Services Administration (GSA) takes
+seriously our responsibility to protect the public's information, including
+financial and personal information, from unwarranted disclosure.
+
+Software developed by the U.S. General Services Administration (GSA)
+is subject to the [GSA Vulnerability Disclosure Policy](https://gsa.gov/vulnerability-disclosure-policy).
+
+Please consult our policy for:
+* How to submit a report if you believe you have discovered a vulnerability.
+* GSA's coordinated disclosure policy.
+* Information on how you may conduct security research on GSA developed
+  software and systems.
+* Important legal and policy guidelines.
+
+## Supported Versions
+
+Please note that only certain branches are supported with security updates.
+
+| Version (Branch) | Supported          |
+| ---------------- | ------------------ |
+| main             | :white_check_mark: |
+| develop          | :white_check_mark: |
+| other            | :x:                |
+
+When using this code or reporting vulnerabilities please only use supported
+versions.


### PR DESCRIPTION
As requested by GSA IT, this adds the GSA security policy to this repo. We support `main` and `develop` with security updates. 