### PR TITLE
Public-sans - POAM: May '24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "gulp-sass": "^5.1.0",
         "path": "^0.12.7",
         "postcss": "^8.4.38",
-        "sass-embedded": "^1.74.1"
+        "sass-embedded": "^1.77.0"
       },
       "devDependencies": {
         "@axe-core/cli": "^4.9.0",
@@ -4886,9 +4886,9 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.74.1.tgz",
-      "integrity": "sha512-VnrsLUfLVuLNq8Zrz6oaYmJ+hK5saaOhuwRC58yAcXYM+CRbS+6us3ab2+PE2a94H2V+cPU4XFvqibfz3C/XSw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.0.tgz",
+      "integrity": "sha512-4GOuLIWQ3vm1XnmRlBz8Rj11rCBceqvkSvEy+ZZGjsR2Y9/+75Dh+zXCtPwOuJFHZsV7qbCqCCSxbpUA0TiQ3w==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
@@ -4901,29 +4901,29 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.74.1",
-        "sass-embedded-android-arm64": "1.74.1",
-        "sass-embedded-android-ia32": "1.74.1",
-        "sass-embedded-android-x64": "1.74.1",
-        "sass-embedded-darwin-arm64": "1.74.1",
-        "sass-embedded-darwin-x64": "1.74.1",
-        "sass-embedded-linux-arm": "1.74.1",
-        "sass-embedded-linux-arm64": "1.74.1",
-        "sass-embedded-linux-ia32": "1.74.1",
-        "sass-embedded-linux-musl-arm": "1.74.1",
-        "sass-embedded-linux-musl-arm64": "1.74.1",
-        "sass-embedded-linux-musl-ia32": "1.74.1",
-        "sass-embedded-linux-musl-x64": "1.74.1",
-        "sass-embedded-linux-x64": "1.74.1",
-        "sass-embedded-win32-arm64": "1.74.1",
-        "sass-embedded-win32-ia32": "1.74.1",
-        "sass-embedded-win32-x64": "1.74.1"
+        "sass-embedded-android-arm": "1.77.0",
+        "sass-embedded-android-arm64": "1.77.0",
+        "sass-embedded-android-ia32": "1.77.0",
+        "sass-embedded-android-x64": "1.77.0",
+        "sass-embedded-darwin-arm64": "1.77.0",
+        "sass-embedded-darwin-x64": "1.77.0",
+        "sass-embedded-linux-arm": "1.77.0",
+        "sass-embedded-linux-arm64": "1.77.0",
+        "sass-embedded-linux-ia32": "1.77.0",
+        "sass-embedded-linux-musl-arm": "1.77.0",
+        "sass-embedded-linux-musl-arm64": "1.77.0",
+        "sass-embedded-linux-musl-ia32": "1.77.0",
+        "sass-embedded-linux-musl-x64": "1.77.0",
+        "sass-embedded-linux-x64": "1.77.0",
+        "sass-embedded-win32-arm64": "1.77.0",
+        "sass-embedded-win32-ia32": "1.77.0",
+        "sass-embedded-win32-x64": "1.77.0"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.74.1.tgz",
-      "integrity": "sha512-1Sy1HP9setmaIFAKKuYpIa3RrKFNmuXhj9sKs8KTWK7+zRSH6R9ZvKRW2R1AwCplQ75XnXSAVmp09rum9SiOcw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.0.tgz",
+      "integrity": "sha512-T/7CXMrRyvb+9FHwXNL53tAnj2z8KqQXpo3XkPXzgB+RFqXhSWsnkfehcefDGm81EsggyYXnkLo6f4xcapZvYw==",
       "cpu": [
         "arm"
       ],
@@ -4939,9 +4939,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.74.1.tgz",
-      "integrity": "sha512-+Ob3WZkR/PzTToPdluptY4BR/+ROCiERr+DT/Fbb31S/DA+HKAegsnwAS4TTnEy8JTtnxFMwSm5xtB9xpchjoQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.0.tgz",
+      "integrity": "sha512-TrKS0AlFu1ZtXR26V8YMnycyE8CR5FPGd+cPkZZeMMXKI8FpbM9W7fz6b+kDJuBZoDmzuHJPoGWSAq+R5k3Hug==",
       "cpu": [
         "arm64"
       ],
@@ -4957,9 +4957,9 @@
       }
     },
     "node_modules/sass-embedded-android-ia32": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.74.1.tgz",
-      "integrity": "sha512-oxKEVvu9VxY1wxhB69HHZlLvhAj3W0gcyFYi88s+gGzgdqpZ2Ohf1z7NJrI+SRUTYVLQ+sWd3Npt0SHWTFoDKA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.0.tgz",
+      "integrity": "sha512-T12iRF3sZ/gRgsEBH6y+eSn12+3VokL6n1+VVlwJ9pYz8Q8iE9gALyvy71Cvm9j130LV4X+pxq53xQl5GA6VQg==",
       "cpu": [
         "ia32"
       ],
@@ -4975,9 +4975,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.74.1.tgz",
-      "integrity": "sha512-Bg5Vx5sgl04K0cHSTniPigiB1zT6nmSJZE8Pq/s35Gze4awzoSDGE8tC65K7f+isKx9FtL9mB+7bEgCJdCvllA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.0.tgz",
+      "integrity": "sha512-qmUoSBywRQkzrFMK6ouifFSCSSb+rK0ykQaD2abeeJ3C9nbEFMUP2M9u6Ny4y1GS9t83MU3LZxwTeEMh7y5/xg==",
       "cpu": [
         "x64"
       ],
@@ -4993,9 +4993,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.74.1.tgz",
-      "integrity": "sha512-DyYmU8qQ7QGGB0RvPUabOsU5YxGxdZd6X3IwyM6KIqziPtjrafoBtcMuWK9o3jg3NE9tL4SUlDezo8VJ87lJ/g==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.0.tgz",
+      "integrity": "sha512-ccLfsrzyS49Em99geabqxueKzEcpIrhUj3oek2+/Ccxllhhwj9LrZFaWlvpHLgzCt/qZldqA4sltqqpczJdHMw==",
       "cpu": [
         "arm64"
       ],
@@ -5011,9 +5011,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.74.1.tgz",
-      "integrity": "sha512-SO3VbGaa/zGzuibiNocSScnS9VZxFY6lULZMfkS6+Sgd3YQgnbvKLaMmfb6kUnETA11rO7jVOTfoNHPtG8n9NA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.0.tgz",
+      "integrity": "sha512-qRDMXlxibTSDyZKDzgHhTCiooCJxodXg1QyE1izcdnSCDX5wOwaK/AShkkmyBQqLM3MQLXTeTgkmV58vEGHeGg==",
       "cpu": [
         "x64"
       ],
@@ -5029,9 +5029,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.74.1.tgz",
-      "integrity": "sha512-mBssC2/aXn1SjI1rM4BM1VPc7w2g8K3Nrq6DDDt4Q10TINBuT3GPnIMb7BlQDpOnHD13GvaL53NDGW3QYWSgew==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.0.tgz",
+      "integrity": "sha512-+Jyiy+ZVjo9dJZbAF8rC0tsmubHbQ6ydv0kWEaiwnEdj2BgpKx/5f2LDlCFgvZkGlPUdKWYNcW6bISUsJjyuJQ==",
       "cpu": [
         "arm"
       ],
@@ -5047,9 +5047,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.74.1.tgz",
-      "integrity": "sha512-sXmREHeqAYwAi71DfnlvyEj0w3B+xMA6C8cIbM4VNP5FCVv4QkIeGCuTH0s/vyBwFKD9+cj9EhQ3UmUUgVP3kg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.0.tgz",
+      "integrity": "sha512-rK1sH+CyMHkYnIkYWVgrHiRI3slpIcBNazQ2vXzRgz8Y0R3+PrOYA8N1QtOoW3ccZPql8/X3NrkopeJbFWCuRg==",
       "cpu": [
         "arm64"
       ],
@@ -5065,9 +5065,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.74.1.tgz",
-      "integrity": "sha512-59n5kFmKcPObQjpK35ww+Fq9FonwZMj3khyl5Cdz2HERdq8nE7JltjdquBNkqp4vSvu7qqnErxFdcZNI1X4LUg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.0.tgz",
+      "integrity": "sha512-SH/RpqFny/2MttLVLBNO2x+D6X7Y/CG3NS2q80RuOlrQvpqgQasw8SqMSx4a07ps1PlOIG5ngYf0agJ3USenJg==",
       "cpu": [
         "ia32"
       ],
@@ -5083,9 +5083,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.74.1.tgz",
-      "integrity": "sha512-xR5hmpRYAvohCRQ2jpkd/p3GHTQ7+KirjQPOaCEzl0RfCPwaqXh91EIvhkuWWE+8Sl9DZd997oucg5leuN6XFQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.0.tgz",
+      "integrity": "sha512-CguyYPc25n/+oIVqbSPX6FTwTPjwd71bt7oZTGZerw8ZocvRDJo6SwjRK2iA8RbHcg0YbFhEwQ9U9SLczykTmA==",
       "cpu": [
         "arm"
       ],
@@ -5098,9 +5098,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.74.1.tgz",
-      "integrity": "sha512-Ws3pMukEKdBXRLroj+kmrJohPIOG43J09sEU/ngxyv8SOKnHdI/5EnhOqJiO+8HUas8Pen/NCYrLYSOydnr3uQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.0.tgz",
+      "integrity": "sha512-2mvAKTqXRRrrnRvUFw/iLozoOW2sj2Q1rOaGFbvXUXYOHYzlVnDTGGVPty+gTN2f1YgUSRe433MtE103Wp9Ekw==",
       "cpu": [
         "arm64"
       ],
@@ -5113,9 +5113,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.74.1.tgz",
-      "integrity": "sha512-F6yQI+VBgsCuriUF4F8SfJq8wiln3OlveWt/DY6DVXxd9oGZBFxZC/YHWcpKexuQtPrFXOVoCNmf0EgiIzAXig==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.0.tgz",
+      "integrity": "sha512-uABIlsNvq7U3wFlpQy5rZ7AsEc7/aKHY4P396YLs52FF/T0NcTx4TjKZwECVHjC+X13ltnmYcAWP8lf8fk5vuQ==",
       "cpu": [
         "ia32"
       ],
@@ -5128,9 +5128,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.74.1.tgz",
-      "integrity": "sha512-qXCMa5Dkt63re5DaRZeD6OXHD9x8DCSWrcX/a+I6RVNNcwz4ez32Fvc8ZAM7QRdMW8w85v7yOFG0FEwZuFYuBQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.0.tgz",
+      "integrity": "sha512-nqf9svqjzrL2i2nu9/hUxE3K4kM0QVegiXiqfw0CoSbwAOQvAaBQxi0k/BgXvurQwJS0ukSs7Zwon5iJ+WDqAA==",
       "cpu": [
         "x64"
       ],
@@ -5143,9 +5143,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.74.1.tgz",
-      "integrity": "sha512-2o6DL/NPLvf7AgNOpq12txhH+s17qlbqCw/BeNFMk9z50LdWkcQZXkDB4R9EA8CwPv65e84/j4+rrxVo8DB1iA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.0.tgz",
+      "integrity": "sha512-KvEE4x0esp0GfGjWGs65AHrHjvxeC5gMKW0VFmWCtH4yT/o5G0eVdgaDXgQqkeLjIOPn5ULFuF2h2euXBuBagw==",
       "cpu": [
         "x64"
       ],
@@ -5161,9 +5161,9 @@
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.74.1.tgz",
-      "integrity": "sha512-y1vliHa37TIfyniKp/G24PUyD2MgbTT3IuuCnkgQjZztiz61Dsmr9g1ueIaWG2EtMGHltG0Ly6uwUzBmqVKKaA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.0.tgz",
+      "integrity": "sha512-dcv09TftEIZQ4LorkrRMYdbUkMiWTpn4nC8i9nKNhjMQ22EE8Jh1SNrR18YTqiYA3YGSc1oEgmDP9cCHHz5HFA==",
       "cpu": [
         "arm64"
       ],
@@ -5179,9 +5179,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.74.1.tgz",
-      "integrity": "sha512-DgaxdgdI6hl8X4cCR0C/8ksGgzA9asvJE3JEZqqmli+cg3QO8om2q3qkJi+3HLuhT3qAzWlGJwlvxm2L5toR3A==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.0.tgz",
+      "integrity": "sha512-j1AStvWCA4RAqDfe12AM7mAYUmSUxDhDktdcPQ2kPo4EiFvjlVFW7CvFM9/MiZ8VvAtop06fyIy8rr+VY8OR2w==",
       "cpu": [
         "ia32"
       ],
@@ -5197,9 +5197,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.74.1.tgz",
-      "integrity": "sha512-4FXBj73rWlzOXQMBtl58F2qjXD2hdO33ozQlY2AviiJfAhdh4lxsuusDn1rLH0ECzoDsIdbDGQdhZ5/n3C8djQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.0.tgz",
+      "integrity": "sha512-J3sjLF0mk1jYD/y3tqxZy3LfoYeyhYAhwJAS6zF9utMb5JIJ+dHscgmuVr87qHCrtOtaV6JRG0oLWi7Uka4nTg==",
       "cpu": [
         "x64"
       ],
@@ -9875,135 +9875,135 @@
       }
     },
     "sass-embedded": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.74.1.tgz",
-      "integrity": "sha512-VnrsLUfLVuLNq8Zrz6oaYmJ+hK5saaOhuwRC58yAcXYM+CRbS+6us3ab2+PE2a94H2V+cPU4XFvqibfz3C/XSw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.0.tgz",
+      "integrity": "sha512-4GOuLIWQ3vm1XnmRlBz8Rj11rCBceqvkSvEy+ZZGjsR2Y9/+75Dh+zXCtPwOuJFHZsV7qbCqCCSxbpUA0TiQ3w==",
       "requires": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
-        "sass-embedded-android-arm": "1.74.1",
-        "sass-embedded-android-arm64": "1.74.1",
-        "sass-embedded-android-ia32": "1.74.1",
-        "sass-embedded-android-x64": "1.74.1",
-        "sass-embedded-darwin-arm64": "1.74.1",
-        "sass-embedded-darwin-x64": "1.74.1",
-        "sass-embedded-linux-arm": "1.74.1",
-        "sass-embedded-linux-arm64": "1.74.1",
-        "sass-embedded-linux-ia32": "1.74.1",
-        "sass-embedded-linux-musl-arm": "1.74.1",
-        "sass-embedded-linux-musl-arm64": "1.74.1",
-        "sass-embedded-linux-musl-ia32": "1.74.1",
-        "sass-embedded-linux-musl-x64": "1.74.1",
-        "sass-embedded-linux-x64": "1.74.1",
-        "sass-embedded-win32-arm64": "1.74.1",
-        "sass-embedded-win32-ia32": "1.74.1",
-        "sass-embedded-win32-x64": "1.74.1",
+        "sass-embedded-android-arm": "1.77.0",
+        "sass-embedded-android-arm64": "1.77.0",
+        "sass-embedded-android-ia32": "1.77.0",
+        "sass-embedded-android-x64": "1.77.0",
+        "sass-embedded-darwin-arm64": "1.77.0",
+        "sass-embedded-darwin-x64": "1.77.0",
+        "sass-embedded-linux-arm": "1.77.0",
+        "sass-embedded-linux-arm64": "1.77.0",
+        "sass-embedded-linux-ia32": "1.77.0",
+        "sass-embedded-linux-musl-arm": "1.77.0",
+        "sass-embedded-linux-musl-arm64": "1.77.0",
+        "sass-embedded-linux-musl-ia32": "1.77.0",
+        "sass-embedded-linux-musl-x64": "1.77.0",
+        "sass-embedded-linux-x64": "1.77.0",
+        "sass-embedded-win32-arm64": "1.77.0",
+        "sass-embedded-win32-ia32": "1.77.0",
+        "sass-embedded-win32-x64": "1.77.0",
         "supports-color": "^8.1.1",
         "varint": "^6.0.0"
       }
     },
     "sass-embedded-android-arm": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.74.1.tgz",
-      "integrity": "sha512-1Sy1HP9setmaIFAKKuYpIa3RrKFNmuXhj9sKs8KTWK7+zRSH6R9ZvKRW2R1AwCplQ75XnXSAVmp09rum9SiOcw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.0.tgz",
+      "integrity": "sha512-T/7CXMrRyvb+9FHwXNL53tAnj2z8KqQXpo3XkPXzgB+RFqXhSWsnkfehcefDGm81EsggyYXnkLo6f4xcapZvYw==",
       "optional": true
     },
     "sass-embedded-android-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.74.1.tgz",
-      "integrity": "sha512-+Ob3WZkR/PzTToPdluptY4BR/+ROCiERr+DT/Fbb31S/DA+HKAegsnwAS4TTnEy8JTtnxFMwSm5xtB9xpchjoQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.0.tgz",
+      "integrity": "sha512-TrKS0AlFu1ZtXR26V8YMnycyE8CR5FPGd+cPkZZeMMXKI8FpbM9W7fz6b+kDJuBZoDmzuHJPoGWSAq+R5k3Hug==",
       "optional": true
     },
     "sass-embedded-android-ia32": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.74.1.tgz",
-      "integrity": "sha512-oxKEVvu9VxY1wxhB69HHZlLvhAj3W0gcyFYi88s+gGzgdqpZ2Ohf1z7NJrI+SRUTYVLQ+sWd3Npt0SHWTFoDKA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.0.tgz",
+      "integrity": "sha512-T12iRF3sZ/gRgsEBH6y+eSn12+3VokL6n1+VVlwJ9pYz8Q8iE9gALyvy71Cvm9j130LV4X+pxq53xQl5GA6VQg==",
       "optional": true
     },
     "sass-embedded-android-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.74.1.tgz",
-      "integrity": "sha512-Bg5Vx5sgl04K0cHSTniPigiB1zT6nmSJZE8Pq/s35Gze4awzoSDGE8tC65K7f+isKx9FtL9mB+7bEgCJdCvllA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.0.tgz",
+      "integrity": "sha512-qmUoSBywRQkzrFMK6ouifFSCSSb+rK0ykQaD2abeeJ3C9nbEFMUP2M9u6Ny4y1GS9t83MU3LZxwTeEMh7y5/xg==",
       "optional": true
     },
     "sass-embedded-darwin-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.74.1.tgz",
-      "integrity": "sha512-DyYmU8qQ7QGGB0RvPUabOsU5YxGxdZd6X3IwyM6KIqziPtjrafoBtcMuWK9o3jg3NE9tL4SUlDezo8VJ87lJ/g==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.0.tgz",
+      "integrity": "sha512-ccLfsrzyS49Em99geabqxueKzEcpIrhUj3oek2+/Ccxllhhwj9LrZFaWlvpHLgzCt/qZldqA4sltqqpczJdHMw==",
       "optional": true
     },
     "sass-embedded-darwin-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.74.1.tgz",
-      "integrity": "sha512-SO3VbGaa/zGzuibiNocSScnS9VZxFY6lULZMfkS6+Sgd3YQgnbvKLaMmfb6kUnETA11rO7jVOTfoNHPtG8n9NA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.0.tgz",
+      "integrity": "sha512-qRDMXlxibTSDyZKDzgHhTCiooCJxodXg1QyE1izcdnSCDX5wOwaK/AShkkmyBQqLM3MQLXTeTgkmV58vEGHeGg==",
       "optional": true
     },
     "sass-embedded-linux-arm": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.74.1.tgz",
-      "integrity": "sha512-mBssC2/aXn1SjI1rM4BM1VPc7w2g8K3Nrq6DDDt4Q10TINBuT3GPnIMb7BlQDpOnHD13GvaL53NDGW3QYWSgew==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.0.tgz",
+      "integrity": "sha512-+Jyiy+ZVjo9dJZbAF8rC0tsmubHbQ6ydv0kWEaiwnEdj2BgpKx/5f2LDlCFgvZkGlPUdKWYNcW6bISUsJjyuJQ==",
       "optional": true
     },
     "sass-embedded-linux-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.74.1.tgz",
-      "integrity": "sha512-sXmREHeqAYwAi71DfnlvyEj0w3B+xMA6C8cIbM4VNP5FCVv4QkIeGCuTH0s/vyBwFKD9+cj9EhQ3UmUUgVP3kg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.0.tgz",
+      "integrity": "sha512-rK1sH+CyMHkYnIkYWVgrHiRI3slpIcBNazQ2vXzRgz8Y0R3+PrOYA8N1QtOoW3ccZPql8/X3NrkopeJbFWCuRg==",
       "optional": true
     },
     "sass-embedded-linux-ia32": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.74.1.tgz",
-      "integrity": "sha512-59n5kFmKcPObQjpK35ww+Fq9FonwZMj3khyl5Cdz2HERdq8nE7JltjdquBNkqp4vSvu7qqnErxFdcZNI1X4LUg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.0.tgz",
+      "integrity": "sha512-SH/RpqFny/2MttLVLBNO2x+D6X7Y/CG3NS2q80RuOlrQvpqgQasw8SqMSx4a07ps1PlOIG5ngYf0agJ3USenJg==",
       "optional": true
     },
     "sass-embedded-linux-musl-arm": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.74.1.tgz",
-      "integrity": "sha512-xR5hmpRYAvohCRQ2jpkd/p3GHTQ7+KirjQPOaCEzl0RfCPwaqXh91EIvhkuWWE+8Sl9DZd997oucg5leuN6XFQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.0.tgz",
+      "integrity": "sha512-CguyYPc25n/+oIVqbSPX6FTwTPjwd71bt7oZTGZerw8ZocvRDJo6SwjRK2iA8RbHcg0YbFhEwQ9U9SLczykTmA==",
       "optional": true
     },
     "sass-embedded-linux-musl-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.74.1.tgz",
-      "integrity": "sha512-Ws3pMukEKdBXRLroj+kmrJohPIOG43J09sEU/ngxyv8SOKnHdI/5EnhOqJiO+8HUas8Pen/NCYrLYSOydnr3uQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.0.tgz",
+      "integrity": "sha512-2mvAKTqXRRrrnRvUFw/iLozoOW2sj2Q1rOaGFbvXUXYOHYzlVnDTGGVPty+gTN2f1YgUSRe433MtE103Wp9Ekw==",
       "optional": true
     },
     "sass-embedded-linux-musl-ia32": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.74.1.tgz",
-      "integrity": "sha512-F6yQI+VBgsCuriUF4F8SfJq8wiln3OlveWt/DY6DVXxd9oGZBFxZC/YHWcpKexuQtPrFXOVoCNmf0EgiIzAXig==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.0.tgz",
+      "integrity": "sha512-uABIlsNvq7U3wFlpQy5rZ7AsEc7/aKHY4P396YLs52FF/T0NcTx4TjKZwECVHjC+X13ltnmYcAWP8lf8fk5vuQ==",
       "optional": true
     },
     "sass-embedded-linux-musl-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.74.1.tgz",
-      "integrity": "sha512-qXCMa5Dkt63re5DaRZeD6OXHD9x8DCSWrcX/a+I6RVNNcwz4ez32Fvc8ZAM7QRdMW8w85v7yOFG0FEwZuFYuBQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.0.tgz",
+      "integrity": "sha512-nqf9svqjzrL2i2nu9/hUxE3K4kM0QVegiXiqfw0CoSbwAOQvAaBQxi0k/BgXvurQwJS0ukSs7Zwon5iJ+WDqAA==",
       "optional": true
     },
     "sass-embedded-linux-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.74.1.tgz",
-      "integrity": "sha512-2o6DL/NPLvf7AgNOpq12txhH+s17qlbqCw/BeNFMk9z50LdWkcQZXkDB4R9EA8CwPv65e84/j4+rrxVo8DB1iA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.0.tgz",
+      "integrity": "sha512-KvEE4x0esp0GfGjWGs65AHrHjvxeC5gMKW0VFmWCtH4yT/o5G0eVdgaDXgQqkeLjIOPn5ULFuF2h2euXBuBagw==",
       "optional": true
     },
     "sass-embedded-win32-arm64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.74.1.tgz",
-      "integrity": "sha512-y1vliHa37TIfyniKp/G24PUyD2MgbTT3IuuCnkgQjZztiz61Dsmr9g1ueIaWG2EtMGHltG0Ly6uwUzBmqVKKaA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.0.tgz",
+      "integrity": "sha512-dcv09TftEIZQ4LorkrRMYdbUkMiWTpn4nC8i9nKNhjMQ22EE8Jh1SNrR18YTqiYA3YGSc1oEgmDP9cCHHz5HFA==",
       "optional": true
     },
     "sass-embedded-win32-ia32": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.74.1.tgz",
-      "integrity": "sha512-DgaxdgdI6hl8X4cCR0C/8ksGgzA9asvJE3JEZqqmli+cg3QO8om2q3qkJi+3HLuhT3qAzWlGJwlvxm2L5toR3A==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.0.tgz",
+      "integrity": "sha512-j1AStvWCA4RAqDfe12AM7mAYUmSUxDhDktdcPQ2kPo4EiFvjlVFW7CvFM9/MiZ8VvAtop06fyIy8rr+VY8OR2w==",
       "optional": true
     },
     "sass-embedded-win32-x64": {
-      "version": "1.74.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.74.1.tgz",
-      "integrity": "sha512-4FXBj73rWlzOXQMBtl58F2qjXD2hdO33ozQlY2AviiJfAhdh4lxsuusDn1rLH0ECzoDsIdbDGQdhZ5/n3C8djQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.0.tgz",
+      "integrity": "sha512-J3sjLF0mk1jYD/y3tqxZy3LfoYeyhYAhwJAS6zF9utMb5JIJ+dHscgmuVr87qHCrtOtaV6JRG0oLWi7Uka4nTg==",
       "optional": true
     },
     "selenium-webdriver": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gulp-sass": "^5.1.0",
     "path": "^0.12.7",
     "postcss": "^8.4.38",
-    "sass-embedded": "^1.74.1"
+    "sass-embedded": "^1.77.0"
   },
   "devDependencies": {
     "@axe-core/cli": "^4.9.0",


### PR DESCRIPTION
# Summary

Update non-vulnerable dependencies

## Testing instructions

1. Running start and serve run without error
2. Gulp commands run without error
  1. `npm run start`
  2. `npm run serve`
  3. `npm run test:a11y` (while localhost is being served from the serve script)

## Dependency updates

| Dependency | Old version | New version |
|--------|--------|--------|
| `sass-embedded` | 1.74.1 | 1.77.0 | 